### PR TITLE
allow multi-tab coexistence, disconnect on error

### DIFF
--- a/js/bbs/bbs_xmpp.js
+++ b/js/bbs/bbs_xmpp.js
@@ -227,6 +227,7 @@ function xmpp_error(error) {
     xmpp_user_list = {}
     $('#xmpp-user-list').empty();
     xmpp_show_loading(bbs_string.xmpp_error);
+    $.xmpp.disconnectSync();
     setTimeout(function() {
         console.log("xmpp error. reconnecting...");
         xmpp_connect();

--- a/js/jquery/jquery.xmpp.js
+++ b/js/jquery/jquery.xmpp.js
@@ -248,14 +248,31 @@
                     xmpp.listening = false;
                     //Do not listen anymore!
                     //Two callbacks
-                    if(callback != null)
-                    callback(data);
-                    if(xmpp.onDisconnect != null)
+                    if(callback != null) {
+                        callback(data);
+                    }
+                    if(xmpp.onDisconnect != null) {
+                        xmpp.onDisconnect(data);
+                    }
                     xmpp.connected = false;
-                    xmpp.onDisconnect(data);
                 },
                 dataType: 'text',
                 async:false
+            }).fail(function(XMLHttpRequest, textStatus, errorThrown) {
+/*                if(xmpp.onError != null){
+                    xmpp.onError({error: errorThrown, data:textStatus});
+                }*/
+                console.log("disconnectSync() error: " + errorThrown);
+                if (xmpp.__lastAjaxRequest != null) {
+                    xmpp.__lastAjaxRequest.abort();
+                }
+                xmpp.connections = xmpp.connections - 1;
+                if (xmpp.debug) {
+                    console.log("connection-- = " + xmpp.connections + ": disconnectSync.error");
+                }
+                xmpp.listening = false;
+                xmpp.connected = false;
+                xmpp.errorCount = xmpp.errorCount + 1;
             });
         },
         


### PR DESCRIPTION
- Allow multi-tab coexistence
  Generate session key for each tab
- Disconnect on error
  So we also disconnect on tab close / refresh, and we won't have multiple connections alive
- Handle some error conditions
  Better error recovery
