### PR TITLE
reset watchdog timer in sendCommand. fix disconnect problem

### DIFF
--- a/js/jquery/jquery.xmpp.js
+++ b/js/jquery/jquery.xmpp.js
@@ -574,8 +574,7 @@
                 xmpp = this;
                 if(xmpp.connections === 0) {
                     //To detect networks problems
-                    clearTimeout(xmpp._jsTimeout);
-                    xmpp._jsTimeout = setTimeout(xmpp.__networkError,xmpp._timeoutMilis);
+                    xmpp.refreshTimer();
                     //
                     this.rid = this.rid+1;
                     xmpp.connections = xmpp.connections + 1;
@@ -630,6 +629,8 @@
         */
         sendCommand: function(rawCommand, callback){
             var self = this;
+
+            self.refreshTimer();
 
             this.rid = this.rid + 1;
             this.listening = true;
@@ -817,6 +818,21 @@
             ret += " type='result'/>";
 
             xmpp.sendCommand(ret);
+        },
+
+        /**
+         * Reset the watchdog timer
+         */
+        refreshTimer: function() {
+            var xmpp = this;
+            if (xmpp.debug) {
+                console.log("clear timeout " + xmpp._jsTimeout);
+            }
+            clearTimeout(xmpp._jsTimeout);
+            xmpp._jsTimeout = setTimeout(xmpp.__networkError,xmpp._timeoutMilis);
+            if (xmpp.debug) {
+                console.log("new timeout set " + xmpp._jsTimeout);
+            }
         }
     }
 })(jQuery);


### PR DESCRIPTION
jquery.xmpp resets a timer before starting the long polling in listen(). In this way, if the long polling fails, it would be notified by the timer timeout.
However, long polling is also started in sendCommand(). If a call to listen() is followed by several calls to sendCommand(), the timer would not be reseted, and it may times out without an error.
By also resetting the timer in sendCommand(), as long as the connection is alive, the timer would always be resetted before a long polling.
Because the system reconnects when disconnected, the timer would not time out during the reconnected period.
An alternative way to achieve this may be setting the timer before the request and clearing it when the request succeeds/fails. 
